### PR TITLE
fix: use agent_message_success event as stop condition

### DIFF
--- a/src/dust_api/api.tsx
+++ b/src/dust_api/api.tsx
@@ -7,7 +7,7 @@ import {
   AgentActionSuccessEvent,
   AgentActionType,
   AgentErrorEvent,
-  AgentGenerationSuccessEvent,
+  AgentMessageSuccessEvent,
   DustAPIErrorResponse,
   DustDocument,
   GenerationTokensEvent,
@@ -103,7 +103,7 @@ export class DustApi {
       | AgentErrorEvent
       | AgentActionSuccessEvent
       | GenerationTokensEvent
-      | AgentGenerationSuccessEvent
+      | AgentMessageSuccessEvent
     )[] = [];
     const parser = createParser((event) => {
       if (event.type === "event") {
@@ -206,6 +206,9 @@ export class DustApi {
             break;
           }
           case "generation_tokens": {
+            if (event.classification !== "tokens") {
+              continue;
+            }
             answer += event.text;
             if (lastSentDate.getTime() + 500 > new Date().getTime()) {
               continue;
@@ -215,8 +218,8 @@ export class DustApi {
             setDustAnswer(dustAnswer + "...");
             break;
           }
-          case "agent_generation_success": {
-            answer = this.processAction({ content: event.text, action, setDustDocuments });
+          case "agent_message_success": {
+            answer = this.processAction({ content: event.message.content ?? "", action, setDustDocuments });
             setDustAnswer(answer);
             if (onDone) {
               onDone(answer);

--- a/src/dust_api/conversation_events.ts
+++ b/src/dust_api/conversation_events.ts
@@ -53,6 +53,29 @@ export type DustDocument = {
   reference: number;
 };
 
+export type AgentMessageType = {
+  id: number;
+  agentMessageId: number;
+  created: number;
+  type: "agent_message";
+  sId: string;
+  visibility: "visible" | "deleted";
+  version: number;
+  parentMessageId: string | null;
+  status: "created" | "succeeded" | "failed" | "cancelled";
+  actions: AgentActionType[];
+  content: string | null;
+  chainOfThought: string | null;
+  rawContents: Array<{
+    step: number;
+    content: string;
+  }>;
+  error: {
+    code: string;
+    message: string;
+  } | null;
+};
+
 export type AgentActionType = RetrievalActionType | DustAppRunActionType;
 
 export type AgentActionSuccessEvent = {
@@ -70,15 +93,17 @@ export type GenerationTokensEvent = {
   configurationId: string;
   messageId: string;
   text: string;
+  classification: "tokens" | "chain_of_thought" | "opening_delimiter" | "closing_delimiter";
 };
 
-// Event sent once the generation is completed.
-export type AgentGenerationSuccessEvent = {
-  type: "agent_generation_success";
+// Event sent once the message is completed and successful.
+export type AgentMessageSuccessEvent = {
+  type: "agent_message_success";
   created: number;
   configurationId: string;
   messageId: string;
-  text: string;
+  message: AgentMessageType;
+  runIds: string[];
 };
 
 // Event sent when the user message is created.
@@ -101,12 +126,4 @@ export type AgentErrorEvent = {
     code: string;
     message: string;
   };
-};
-
-export type GenerationSuccessEvent = {
-  type: "generation_success";
-  created: number;
-  configurationId: string;
-  messageId: string;
-  text: string;
 };


### PR DESCRIPTION
- Update the `conversation_events` module with latest changes to Dust typescript types
- Change streaming logic to use the `AgentMessageSuccess`  event as the stop condition
- Change streaming logic to avoid streaming Chain Of Thought tokens